### PR TITLE
Flexibility of passing port from a command line arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ cd AATT
 sudo npm install
 git submodule init
 git submodule update
-$ node app.js
+$ DEBUG=AATT* http_port=3000 node app.js
 ```
 
-You can now access the running instance of AATT from https://localhost
+You can now access the running instance of AATT from http://localhost:3000
 *Note*: if you get "access" errors from Node, please make sure to shut down your Apache server by running the following from the command line:
 
 ```sh
@@ -41,7 +41,7 @@ $ sudo apachectl stop
 ```
 
 ## Integration with AATT API
-AATT has an APIfor evaluating HTML Source code from other servers. The API EndPoint is: https://your_nodejs_server/evaluate
+AATT provides an API for evaluating HTML Source code from other servers. The API EndPoint is: https://your_nodejs_server/evaluate
 
 * Accepts the following parameters:
   1. "source" to send the HTML source of the page. Can be a whole page or partial page source 

--- a/package.json
+++ b/package.json
@@ -4,11 +4,13 @@
   "description": "Automated Accessibility Testing Tool",
   "main": "app.js",
   "dependencies": {
+    "body-parser": "~1.10.1",
     "consolidate": "~0.10.0",
+    "debug": "^2.2.0",
     "express": "~4.10.7",
     "express-session": "~1.10.1",
     "handlebars": "~2.0.0",
-    "body-parser": "~1.10.1",
+    "nconf": "^0.7.2",
     "phantomjs": "~1.9.13"
   },
   "devDependencies": {},


### PR DESCRIPTION
- Now users can pass `http_port` or `https_port` via a command line like
`http_port=3000 node app.js`
- Added excellent tiny [debug](https://github.com/visionmedia/debug) library to replace console.log/error statements. Users can enable debug statements by providing flag like,
`DEBUG=AATT* http_port=3000 node app.js`
- Documentation updated!