### PR TITLE
Use as node module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # Automated Accessibility Testing Tool (AATT)
 
 Browser-based accessibility testing tools and plugins require manually testing each page, one at a time. Tools that can crawl a website can only scan pages that do not require login credentials, and that are not behind a firewall. Instead of developing, testing, and using a separate accessibility test suite, you can now integrate accessibility testing into your existing automation test suite using AATT.
- 
-AATT tests web applications regarding conformance to the Web Content Accessibility Guidelines (WCAG) 2.0. 
+
+AATT tests web applications regarding conformance to the Web Content Accessibility Guidelines (WCAG) 2.0.
 Find a list of the WCAG 2.0 rules checked by HTMLCS Engine on the [HTML CodeSniffer WCAG Standard Summary](http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/) page and Chrome Engine on the [Google Chrome Developer Audit rules](https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules).
 AATT provides an accessibility API and custom web application for [HTML CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/), [Axe](https://github.com/dequelabs/axe-core) and [Chrome developer tool](https://github.com/GoogleChrome/accessibility-developer-tools).  Using the AATT web application, you can configure test server configurations inside the firewall, and test individual pages.
 
-AATT includes [HTML CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/), [Axe](https://github.com/dequelabs/axe-core) and [Chrome developer tool](https://github.com/GoogleChrome/accessibility-developer-tools) with Express and PhantomJS, which runs on Node. 
+AATT includes [HTML CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/), [Axe](https://github.com/dequelabs/axe-core) and [Chrome developer tool](https://github.com/GoogleChrome/accessibility-developer-tools) with Express and PhantomJS, which runs on Node.
 
-For example, it can be used to test Java web applications using [SeLion](https://github.com/paypal/selion/) automation test frameworks. 
+For example, it can be used to test Java web applications using [SeLion](https://github.com/paypal/selion/) automation test frameworks.
 
 For node applications, it can be integrated into [NemoJS testing framework](https://github.com/paypal/nemo)  to run accessibility testing during automated unit testing .For Nemo framework use [Nemo-Accessibility plugin] (https://github.com/paypal/nemo-accessibility)
 
@@ -45,23 +45,23 @@ $ sudo apachectl stop
 AATT provides an API for evaluating HTML Source code from other servers. The API EndPoint is: https://your_nodejs_server/evaluate
 
 * Accepts the following parameters:
-  1. "source" to send the HTML source of the page. Can be a whole page or partial page source 
-  2. "engine" E.g. engine=htmlcs. This is the engine which will scan the code. It accepts a single value of "axe", chrome" or "htmlcs". 
+  1. "source" to send the HTML source of the page. Can be a whole page or partial page source
+  2. "engine" E.g. engine=htmlcs. This is the engine which will scan the code. It accepts a single value of "axe", chrome" or "htmlcs".
   3. "ouput" to get the jsonified string. E.g. output=json.  If this parameter is not set or left empty, it will return a string with table data that can be parsed or appended directly into your page.
   Default to "htmlcs"
   4. "errLevel" Error level like Error, Warning or Notices .  Mapped to 1, 2 and 3 respectively. E.g. "1,2,3"
   5. "level" This option applies only for the default htmlcs evaluation engine. Options can be either of the following WCAG2AA, WCAG2A, WCAG2AAA, Section508  . Defaults to "WCAG2A"
 
-    
+
 * Set the Request Header Content-type as application/x-www-form-urlencoded
 
 ## Example
- 
+
 Here is a sample ajax script which would initiate the request:
 
 ``` html
 var xmlhttp = new XMLHttpRequest();
-xmlhttp.open("POST","http://your_nodejs_server/evaluate",true); 
+xmlhttp.open("POST","http://your_nodejs_server/evaluate",true);
 xmlhttp.setRequestHeader("Content-type","application/x-www-form-urlencoded");
 xmlhttp.send("source=" + document.getElementById('source').value + "&priority=" + document.getElementById('priority').value);
 
@@ -85,7 +85,7 @@ Once `nemo-accessibility` plugin is registered, you should now have `nemo.access
 ```javascript
   var options = {
     'element': driver.findElement(wd.tagName('iframe')), //default is entire page
-    'engine': 'axe', 'htmlcs' or 'chrome', //default is htmlcs    
+    'engine': 'axe', 'htmlcs' or 'chrome', //default is htmlcs
     'output': 'html' or 'json', //default is html,
     'level': 'WCAG2AA' or 'WCAG2A' or  'WCAG2AAA' //option applies to htmlcs only and default to WCAG2AA
     'errLevel' : '1,2,3'   // for htmlcs only, 1 means Error, 2 means Warning, 3 means Notice  default:1,2,3
@@ -116,7 +116,7 @@ Here is a  [example](https://github.com/paypal/nemo-accessibility/blob/master/ex
             'engine' : 'htmlcs',
             'errLevel': '1,2,3'
 
-        };        
+        };
         nemo.accessibility.scan(options).then(function (result) {
             fs.writeFile('report/entirePage.html',result,function (err) {
                done();
@@ -140,19 +140,49 @@ Here is a  [example](https://github.com/paypal/nemo-accessibility/blob/master/ex
 For more details, please refer to: [nemo-accessibility plugin](https://github.com/paypal/nemo-accessibility)
 
 ## How to Use with nightwatchJS
-[Nightwatch JS](http://nightwatchjs.org ) is another UI automated testing framework powered by Node.js and uses the Selenium WebDriver API. To call AATT, you need to use the [request module](https://github.com/request/request). NightwatchJs has call back functions like before and after hooks that would be called before or after executing a test case. Request to AATT API should be done in after hook passing the source code of the page to the API.  Here is an [example commit](https://github.com/mpnkhan/nightwatch/commit/a377e860e0bfbd21d9e365e86fb3e6c4ec0e63f0)  on how to do this with Nightwatch. 
+[Nightwatch JS](http://nightwatchjs.org ) is another UI automated testing framework powered by Node.js and uses the Selenium WebDriver API. To call AATT, you need to use the [request module](https://github.com/request/request). NightwatchJs has call back functions like before and after hooks that would be called before or after executing a test case. Request to AATT API should be done in after hook passing the source code of the page to the API.  Here is an [example commit](https://github.com/mpnkhan/nightwatch/commit/a377e860e0bfbd21d9e365e86fb3e6c4ec0e63f0)  on how to do this with Nightwatch.
 
-## How to Use the AATT web application 
- 
-The AATT web application can be used to test HTML code snippets or pages. To test logged in pages on a test server, first configure the login credentials in AATT which creates a cookied experience. Then, enter the url for the page you want to test. 
+## How to Use the AATT web application
+
+The AATT web application can be used to test HTML code snippets or pages. To test logged in pages on a test server, first configure the login credentials in AATT which creates a cookied experience. Then, enter the url for the page you want to test.
 Results are displayed as a table that can be exported as a CSV file.
-Results include:  
-* WCAG 2.0 principle: Perceivable, Operable, Understandable or Robust 
+Results include:
+* WCAG 2.0 principle: Perceivable, Operable, Understandable or Robust
 * Error description
 * code snippet
-* WCAG 2.0 techniques to help developers fix the issue. 
+* WCAG 2.0 techniques to help developers fix the issue.
 
 Optionally, you can configure the tool to save a screensnap of the html page you test. You can also configure the tool to display only errors, or also to include warnings and notices. Warning and notices require manual inspection to determine the severity of the warning or notice.
+
+## How to use as a node module
+
+The AATT evaluate function can be used directly as a node module, without the
+need for using a web API.
+
+### Installation
+
+Add the module to your project
+
+```sh
+npm install --save aatt
+```
+
+### Usage Example
+
+This takes the same options as the web `/evaluate` HTTP endpoint.
+
+```javascript
+const { evaluate } = require('aatt');
+
+evaluate({
+    source: "<html xml:lang='en-gb'><head><title>Foo</title></head><body><p>Bar</p></body></html>",
+    output: "json",
+    engine: "htmlcs",
+    level: "WCAG2A"
+}).then(result => {
+    console.log('Results', JSON.parse(result));
+});
+```
 
 ## Copyright and License
 

--- a/app.js
+++ b/app.js
@@ -1,7 +1,7 @@
 //R E Q U I R E S
 var express = require('express')
 var app = express();
-var http = require('http'); 
+var http = require('http');
 var https = require('https');
 var cons = require('consolidate')
 var childProcess = require('child_process');
@@ -15,6 +15,7 @@ var debug = require('debug');
 var log = debug('AATT:log');
 var error = debug('AATT:error');
 var nconf = require('nconf');
+var { evaluate } = require('./module.js');
 
 nconf.env().argv();
 
@@ -40,13 +41,13 @@ app.use(express.static(path.join(__dirname, 'public')));
 app.use(express.static(path.join(__dirname, 'src')));
 app.use('/test', express.static(__dirname + '/test'));
 app.use('/screenshots', express.static(__dirname + '/screenshots'));
-app.use('/Auditor',express.static(path.join(__dirname, 'src/HTML_CodeSniffer/Auditor')));    
+app.use('/Auditor',express.static(path.join(__dirname, 'src/HTML_CodeSniffer/Auditor')));
 app.use('/Images',express.static(path.join(__dirname, 'src/HTML_CodeSniffer/Auditor/Images')));
 
 
 if (fs.existsSync(ssl_path)) {
 		var hskey = fs.readFileSync(ssl_path);
-		var hscert = fs.readFileSync(cert_file) ; 	
+		var hscert = fs.readFileSync(cert_file) ;
 		var options = {
 		    key: hskey,
 		    cert: hscert
@@ -57,7 +58,7 @@ if (fs.existsSync(ssl_path)) {
 
 } else {
 		var server = http.createServer(app);
-		app.listen(http_port);					
+		app.listen(http_port);
 		log('Express started on port ', http_port);
 }
 
@@ -117,10 +118,10 @@ if (fs.existsSync(ssl_path)) {
 		}
 		if(engine === 'axe'){
 			childArgs = ['--config=config/config.json', path.join(__dirname, 'src/axe_url.js'), req.body.textURL, output];
-		}	
+		}
 		if(engine === 'chrome'){
 			childArgs = ['--config=config/config.json', path.join(__dirname, 'src/chrome_url.js'), req.body.textURL, output];
-		}	
+		}
 		childProcess.execFile(binPath, childArgs, function(err, stdout, stderr) {
 			res.json({ userName: userName, data: stdout });
 			log(stdout);
@@ -154,11 +155,11 @@ if (fs.existsSync(ssl_path)) {
 			}
 			if(engine === 'axe'){
 				var childArgs = ['--config=config/config.json', path.join(__dirname, 'src/axe_url.js'),  tempFilename, output];
-			}	 	
+			}
 			if(engine === 'chrome'){
 				var childArgs = ['--config=config/config.json', path.join(__dirname, 'src/chrome_url.js'), tempFilename, output]
-			}	 	
-	
+			}
+
 			childProcess.execFile(binPath, childArgs, function(err, stdout, stderr) {
 				res.json(stdout);
 				log(stdout);
@@ -166,9 +167,9 @@ if (fs.existsSync(ssl_path)) {
 					if (err) {
 						console.log("failed to delete : "+ err);
 					} else {
-						console.log('successfully deleted ' + tempFilename);                                
+						console.log('successfully deleted ' + tempFilename);
 					}
-				});				
+				});
 			});
 		});		//fs.writeFile
 	});
@@ -198,7 +199,7 @@ if (fs.existsSync(ssl_path)) {
 				});
 				delete req.session.userName;
 			}
-			res.redirect('/');	
+			res.redirect('/');
 	});
 
 	app.post('/evaluate', function(req, res) {
@@ -206,42 +207,12 @@ if (fs.existsSync(ssl_path)) {
 		var output = req.body.output;		// Eg. json, string  		default: string
 		var level = req.body.level;			//E.g. WCAG2AA, WCAG2A, WCAG2AAA, Section508 	default:WCAG2AA
 		var errLevel = req.body.errLevel;	// Eg. 1,2,3   1 means Error, 2 means Warning, 3 means Notice 	default:1,2,3
-		var tempFilename = 'tmp/'+ new Date().getTime() + '.html';
-
-		if(typeof engine === 'undefined' || engine ==='') engine = 'htmlcs';
-		if(typeof output === 'undefined' || output ==='') output = 'string';
-		if(typeof level === 'undefined' || level ==='') level = 'WCAG2AA';
-		if(typeof errLevel === 'undefined' || errLevel ==='') errLevel = '1';
-
 		var source = req.body.source;
-		source = source.replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi,'');	//replaces script tags
 
-		fs.writeFile(tempFilename, source , function (err,data) {
-			if (err) throw err;
-			if(engine === 'htmlcs'){
-				var childArgs = ['--config=config/config.json', path.join(__dirname, 'src/HTMLCS_Run.js'), tempFilename, level, errLevel, output];
-			}
-			if(engine === 'axe'){
-				var childArgs = ['--config=config/config.json', path.join(__dirname, 'src/axe_url.js'),  tempFilename, output];
-			}	 	
-			if(engine === 'chrome'){
-				var childArgs = ['--config=config/config.json', path.join(__dirname, 'src/chrome_url.js'), tempFilename, output]
-			}
-			console.log('E N G I N E ' , engine, childArgs);
-
-			childProcess.execFile(binPath, childArgs, function(err, stdout, stderr) {
-				stdout = stdout.replace('done','');
-				res.writeHead(200, { 'Content-Type': 'text/plain', "Access-Control-Allow-Origin":"*" });
-				res.write(stdout);
-				res.end();
-				log(stdout);
-				fs.unlink(tempFilename, (err) => {
-					if (err) {
-						console.log("failed to delete : "+ err);
-					} else {
-						console.log('successfully deleted ' + tempFilename);                                
-					}
-				});
-			})
-		})		
+		evaluate(req.body).then(function(stdout) {
+			res.writeHead(200, { 'Content-Type': 'text/plain', "Access-Control-Allow-Origin":"*" });
+			res.write(stdout);
+			res.end();
+			log(stdout);
+		});
 	})

--- a/app.js
+++ b/app.js
@@ -203,16 +203,10 @@ if (fs.existsSync(ssl_path)) {
 	});
 
 	app.post('/evaluate', function(req, res) {
-		var engine	= req.body.engine;		//Eg htmlcs, chrome, axe 		default:htmlcs
-		var output = req.body.output;		// Eg. json, string  		default: string
-		var level = req.body.level;			//E.g. WCAG2AA, WCAG2A, WCAG2AAA, Section508 	default:WCAG2AA
-		var errLevel = req.body.errLevel;	// Eg. 1,2,3   1 means Error, 2 means Warning, 3 means Notice 	default:1,2,3
-		var source = req.body.source;
-
-		evaluate(req.body).then(function(stdout) {
+		evaluate(req.body, true).then(function(stdout) {
 			res.writeHead(200, { 'Content-Type': 'text/plain', "Access-Control-Allow-Origin":"*" });
 			res.write(stdout);
 			res.end();
 			log(stdout);
 		});
-	})
+	});

--- a/module.js
+++ b/module.js
@@ -2,7 +2,7 @@ var fs = require('fs');
 var path =require('path');
 var childProcess = require('child_process');
 var phantomjs = require('phantomjs/lib/phantomjs');
-var binPath = phantomjs.path
+var binPath = phantomjs.path;
 
 function evaluate(options) {
     var engine  = options.engine;      //Eg htmlcs, chrome, axe        default:htmlcs
@@ -10,7 +10,7 @@ function evaluate(options) {
     var level = options.level;         //E.g. WCAG2AA, WCAG2A, WCAG2AAA, Section508    default:WCAG2AA
     var errLevel = options.errLevel;   // Eg. 1,2,3   1 means Error, 2 means Warning, 3 means Notice   default:1,2,3
     var source = options.source;
-    var tempFilename = 'tmp/'+ new Date().getTime() + '.html';
+    var tempFilename = path.join(__dirname, 'tmp', new Date().getTime() + '.html');
 
     if(typeof engine === 'undefined' || engine ==='') engine = 'htmlcs';
     if(typeof output === 'undefined' || output ==='') output = 'string';
@@ -22,18 +22,20 @@ function evaluate(options) {
     return new Promise(resolve => {
         fs.writeFile(tempFilename, source , function (err,data) {
             if (err) throw err;
+            var config = '--config=' + path.join(__dirname, 'config', 'config.json');
+
             if(engine === 'htmlcs'){
-                var childArgs = ['--config=config/config.json', path.join(__dirname, 'src/HTMLCS_Run.js'), tempFilename, level, errLevel, output];
+                var childArgs = [config, path.join(__dirname, 'src/HTMLCS_Run.js'), tempFilename, level, errLevel, output];
             }
             if(engine === 'axe'){
-                var childArgs = ['--config=config/config.json', path.join(__dirname, 'src/axe_url.js'),  tempFilename, output];
+                var childArgs = [config, path.join(__dirname, 'src/axe_url.js'),  tempFilename, output];
             }
             if(engine === 'chrome'){
-                var childArgs = ['--config=config/config.json', path.join(__dirname, 'src/chrome_url.js'), tempFilename, output]
+                var childArgs = [config, path.join(__dirname, 'src/chrome_url.js'), tempFilename, output]
             }
-            console.log('E N G I N E ' , engine, childArgs);
+            console.log('E N G I N E ' , engine, binPath, childArgs);
 
-            childProcess.execFile(binPath, childArgs, function(err, stdout, stderr) {
+            childProcess.execFile(binPath, childArgs, { cwd: __dirname }, function(err, stdout, stderr) {
                 stdout = stdout.replace('done','');
 
                 resolve(stdout);

--- a/module.js
+++ b/module.js
@@ -1,0 +1,53 @@
+var fs = require('fs');
+var path =require('path');
+var childProcess = require('child_process');
+var phantomjs = require('phantomjs/lib/phantomjs');
+var binPath = phantomjs.path
+
+function evaluate(options) {
+    var engine  = options.engine;      //Eg htmlcs, chrome, axe        default:htmlcs
+    var output = options.output;       // Eg. json, string         default: string
+    var level = options.level;         //E.g. WCAG2AA, WCAG2A, WCAG2AAA, Section508    default:WCAG2AA
+    var errLevel = options.errLevel;   // Eg. 1,2,3   1 means Error, 2 means Warning, 3 means Notice   default:1,2,3
+    var source = options.source;
+    var tempFilename = 'tmp/'+ new Date().getTime() + '.html';
+
+    if(typeof engine === 'undefined' || engine ==='') engine = 'htmlcs';
+    if(typeof output === 'undefined' || output ==='') output = 'string';
+    if(typeof level === 'undefined' || level ==='') level = 'WCAG2AA';
+    if(typeof errLevel === 'undefined' || errLevel ==='') errLevel = '1';
+
+    source = source.replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi,'');  //replaces script tags
+
+    return new Promise(resolve => {
+        fs.writeFile(tempFilename, source , function (err,data) {
+            if (err) throw err;
+            if(engine === 'htmlcs'){
+                var childArgs = ['--config=config/config.json', path.join(__dirname, 'src/HTMLCS_Run.js'), tempFilename, level, errLevel, output];
+            }
+            if(engine === 'axe'){
+                var childArgs = ['--config=config/config.json', path.join(__dirname, 'src/axe_url.js'),  tempFilename, output];
+            }
+            if(engine === 'chrome'){
+                var childArgs = ['--config=config/config.json', path.join(__dirname, 'src/chrome_url.js'), tempFilename, output]
+            }
+            console.log('E N G I N E ' , engine, childArgs);
+
+            childProcess.execFile(binPath, childArgs, function(err, stdout, stderr) {
+                stdout = stdout.replace('done','');
+
+                resolve(stdout);
+
+                fs.unlink(tempFilename, (err) => {
+                    if (err) {
+                        console.log("failed to delete : "+ err);
+                    } else {
+                        console.log('successfully deleted ' + tempFilename);
+                    }
+                });
+            })
+        })
+    });
+}
+
+module.exports = { evaluate };

--- a/module.js
+++ b/module.js
@@ -4,7 +4,7 @@ var childProcess = require('child_process');
 var phantomjs = require('phantomjs/lib/phantomjs');
 var binPath = phantomjs.path;
 
-function evaluate(options) {
+function evaluate(options, logging = false) {
     var engine  = options.engine;      //Eg htmlcs, chrome, axe        default:htmlcs
     var output = options.output;       // Eg. json, string         default: string
     var level = options.level;         //E.g. WCAG2AA, WCAG2A, WCAG2AAA, Section508    default:WCAG2AA
@@ -19,7 +19,7 @@ function evaluate(options) {
 
     source = source.replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi,'');  //replaces script tags
 
-    return new Promise(resolve => {
+    return new Promise(function(resolve) {
         fs.writeFile(tempFilename, source , function (err,data) {
             if (err) throw err;
             var config = '--config=' + path.join(__dirname, 'config', 'config.json');
@@ -33,7 +33,7 @@ function evaluate(options) {
             if(engine === 'chrome'){
                 var childArgs = [config, path.join(__dirname, 'src/chrome_url.js'), tempFilename, output]
             }
-            console.log('E N G I N E ' , engine, binPath, childArgs);
+            if (logging) console.log('E N G I N E ' , engine, binPath, childArgs);
 
             childProcess.execFile(binPath, childArgs, { cwd: __dirname }, function(err, stdout, stderr) {
                 stdout = stdout.replace('done','');
@@ -41,6 +41,8 @@ function evaluate(options) {
                 resolve(stdout);
 
                 fs.unlink(tempFilename, (err) => {
+                    if (!logging) return;
+
                     if (err) {
                         console.log("failed to delete : "+ err);
                     } else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1354 @@
+{
+  "name": "aatt",
+  "version": "0.0.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "accepts": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.1.4.tgz",
+      "integrity": "sha1-1xyW99QdD+2iw4zRToonwEFY30o=",
+      "requires": {
+        "mime-types": "~2.0.4",
+        "negotiator": "0.4.9"
+      }
+    },
+    "align-text": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+      "requires": {
+        "kind-of": "^3.0.2",
+        "longest": "^1.0.1",
+        "repeat-string": "^1.5.2"
+      }
+    },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+    },
+    "ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+    },
+    "asn1": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "requires": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "assert-plus": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
+    },
+    "async": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+      "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+      "requires": {
+        "lodash": "^4.17.10"
+      }
+    },
+    "aws-sign2": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+      "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "base64-url": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.1.tgz",
+      "integrity": "sha1-GZ/WYXAqDnt9yubgaYuwicUvbXg="
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "requires": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
+    "bl": {
+      "version": "1.0.3",
+      "resolved": "http://registry.npmjs.org/bl/-/bl-1.0.3.tgz",
+      "integrity": "sha1-/FQhoo/UImA2w7OJGmaiW8ZNIm4=",
+      "requires": {
+        "readable-stream": "~2.0.5"
+      }
+    },
+    "body-parser": {
+      "version": "1.10.2",
+      "resolved": "http://registry.npmjs.org/body-parser/-/body-parser-1.10.2.tgz",
+      "integrity": "sha1-QF1GX808zw6oo1rb8QVfbpgxa9E=",
+      "requires": {
+        "bytes": "1.0.0",
+        "depd": "~1.0.0",
+        "iconv-lite": "0.4.6",
+        "media-typer": "0.3.0",
+        "on-finished": "~2.2.0",
+        "qs": "2.3.3",
+        "raw-body": "1.3.2",
+        "type-is": "~1.5.5"
+      }
+    },
+    "boom": {
+      "version": "2.10.1",
+      "resolved": "http://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+      "requires": {
+        "hoek": "2.x.x"
+      }
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "bytes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz",
+      "integrity": "sha1-NWnt6Lo0MV+rmcPpLLBMciDeH6g="
+    },
+    "camelcase": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+      "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
+    },
+    "caseless": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+      "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c="
+    },
+    "center-align": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+      "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+      "requires": {
+        "align-text": "^0.1.3",
+        "lazy-cache": "^1.0.3"
+      }
+    },
+    "chalk": {
+      "version": "1.1.3",
+      "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "requires": {
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
+      }
+    },
+    "cliui": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+      "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+      "requires": {
+        "center-align": "^0.1.1",
+        "right-align": "^0.1.1",
+        "wordwrap": "0.0.2"
+      },
+      "dependencies": {
+        "wordwrap": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8="
+        }
+      }
+    },
+    "combined-stream": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
+      "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
+    "commander": {
+      "version": "2.17.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
+      "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg=="
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "concat-stream": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
+      "integrity": "sha1-U/fUPFHF5D+ByP3QMyHGMb5o1hE=",
+      "requires": {
+        "inherits": "~2.0.1",
+        "readable-stream": "~2.0.0",
+        "typedarray": "~0.0.5"
+      }
+    },
+    "consolidate": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/consolidate/-/consolidate-0.10.0.tgz",
+      "integrity": "sha1-gfGmzroSR9+c73omHOUnws5Tj3o="
+    },
+    "content-disposition": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.0.tgz",
+      "integrity": "sha1-QoT+auBjCHRjnkToCkGMKTQTXp4="
+    },
+    "cookie": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.2.tgz",
+      "integrity": "sha1-cv7D0k5Io0Mgc9kMEmQgBQYQBLE="
+    },
+    "cookie-signature": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.5.tgz",
+      "integrity": "sha1-oSLj8VA+yg9TVXlbBxG7I2jUUPk="
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "crc": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/crc/-/crc-3.2.1.tgz",
+      "integrity": "sha1-XZyPt3okXNXsopHl0tAFM0urAII="
+    },
+    "cryptiles": {
+      "version": "2.0.5",
+      "resolved": "http://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+      "requires": {
+        "boom": "2.x.x"
+      }
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "requires": {
+        "assert-plus": "^1.0.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        }
+      }
+    },
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "depd": {
+      "version": "1.0.1",
+      "resolved": "http://registry.npmjs.org/depd/-/depd-1.0.1.tgz",
+      "integrity": "sha1-gK7GTJ1tl+ZcwqnKqTwKpqv3Oqo="
+    },
+    "destroy": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.3.tgz",
+      "integrity": "sha1-tDO0ck5x/YVR2YhRdIUcX8N34sk="
+    },
+    "ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "requires": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
+    "ee-first": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.0.tgz",
+      "integrity": "sha1-ag18YiHkkP7v2S7D9EHJzozQl/Q="
+    },
+    "escape-html": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz",
+      "integrity": "sha1-GBoobq05ejmpKFfPsdQwUuNWv/A="
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
+    "etag": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.5.1.tgz",
+      "integrity": "sha1-VMUN4E7kJpVWKSWsVmWIKRvn6eo=",
+      "requires": {
+        "crc": "3.2.1"
+      }
+    },
+    "express": {
+      "version": "4.10.8",
+      "resolved": "http://registry.npmjs.org/express/-/express-4.10.8.tgz",
+      "integrity": "sha1-LYNXHgZcDvsmecCl+a5mrqpHAko=",
+      "requires": {
+        "accepts": "~1.1.4",
+        "content-disposition": "0.5.0",
+        "cookie": "0.1.2",
+        "cookie-signature": "1.0.5",
+        "debug": "~2.1.1",
+        "depd": "~1.0.0",
+        "escape-html": "1.0.1",
+        "etag": "~1.5.1",
+        "finalhandler": "0.3.3",
+        "fresh": "0.2.4",
+        "media-typer": "0.3.0",
+        "merge-descriptors": "0.0.2",
+        "methods": "1.1.1",
+        "on-finished": "~2.2.0",
+        "parseurl": "~1.3.0",
+        "path-to-regexp": "0.1.3",
+        "proxy-addr": "~1.0.5",
+        "qs": "2.3.3",
+        "range-parser": "~1.0.2",
+        "send": "0.10.1",
+        "serve-static": "~1.7.2",
+        "type-is": "~1.5.5",
+        "utils-merge": "1.0.0",
+        "vary": "~1.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.1.3",
+          "resolved": "http://registry.npmjs.org/debug/-/debug-2.1.3.tgz",
+          "integrity": "sha1-zoqxte6PvuK/o7Yzyrk9NmtjQY4=",
+          "requires": {
+            "ms": "0.7.0"
+          }
+        },
+        "ms": {
+          "version": "0.7.0",
+          "resolved": "http://registry.npmjs.org/ms/-/ms-0.7.0.tgz",
+          "integrity": "sha1-hlvpTC5zl62KV9pqYzpuLzB5i4M="
+        }
+      }
+    },
+    "express-session": {
+      "version": "1.10.4",
+      "resolved": "http://registry.npmjs.org/express-session/-/express-session-1.10.4.tgz",
+      "integrity": "sha1-BOHZLgBZOJPh92Vp6zrWMRPa+Uw=",
+      "requires": {
+        "cookie": "0.1.2",
+        "cookie-signature": "1.0.6",
+        "crc": "3.2.1",
+        "debug": "~2.1.3",
+        "depd": "~1.0.0",
+        "on-headers": "~1.0.0",
+        "parseurl": "~1.3.0",
+        "uid-safe": "1.1.0",
+        "utils-merge": "1.0.0"
+      },
+      "dependencies": {
+        "cookie-signature": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+          "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+        },
+        "debug": {
+          "version": "2.1.3",
+          "resolved": "http://registry.npmjs.org/debug/-/debug-2.1.3.tgz",
+          "integrity": "sha1-zoqxte6PvuK/o7Yzyrk9NmtjQY4=",
+          "requires": {
+            "ms": "0.7.0"
+          }
+        },
+        "ms": {
+          "version": "0.7.0",
+          "resolved": "http://registry.npmjs.org/ms/-/ms-0.7.0.tgz",
+          "integrity": "sha1-hlvpTC5zl62KV9pqYzpuLzB5i4M="
+        }
+      }
+    },
+    "extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+    },
+    "extract-zip": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.5.0.tgz",
+      "integrity": "sha1-ksz22B73Cp+kwXRxFMzvbYaIpsQ=",
+      "requires": {
+        "concat-stream": "1.5.0",
+        "debug": "0.7.4",
+        "mkdirp": "0.5.0",
+        "yauzl": "2.4.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "0.7.4",
+          "resolved": "http://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
+          "integrity": "sha1-BuHqgILCyxTjmAbiLi9vdX+Srzk="
+        }
+      }
+    },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+    },
+    "fd-slicer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
+      "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
+      "requires": {
+        "pend": "~1.2.0"
+      }
+    },
+    "finalhandler": {
+      "version": "0.3.3",
+      "resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-0.3.3.tgz",
+      "integrity": "sha1-saCaoeamB7NUFmmwm8tyf0YM1CY=",
+      "requires": {
+        "debug": "~2.1.1",
+        "escape-html": "1.0.1",
+        "on-finished": "~2.2.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.1.3",
+          "resolved": "http://registry.npmjs.org/debug/-/debug-2.1.3.tgz",
+          "integrity": "sha1-zoqxte6PvuK/o7Yzyrk9NmtjQY4=",
+          "requires": {
+            "ms": "0.7.0"
+          }
+        },
+        "ms": {
+          "version": "0.7.0",
+          "resolved": "http://registry.npmjs.org/ms/-/ms-0.7.0.tgz",
+          "integrity": "sha1-hlvpTC5zl62KV9pqYzpuLzB5i4M="
+        }
+      }
+    },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+    },
+    "form-data": {
+      "version": "1.0.1",
+      "resolved": "http://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz",
+      "integrity": "sha1-rjFduaSQf6BlUCMEpm13M0de43w=",
+      "requires": {
+        "async": "^2.0.1",
+        "combined-stream": "^1.0.5",
+        "mime-types": "^2.1.11"
+      },
+      "dependencies": {
+        "mime-db": {
+          "version": "1.37.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
+          "integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg=="
+        },
+        "mime-types": {
+          "version": "2.1.21",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
+          "integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
+          "requires": {
+            "mime-db": "~1.37.0"
+          }
+        }
+      }
+    },
+    "forwarded": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
+      "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
+    },
+    "fresh": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.2.4.tgz",
+      "integrity": "sha1-NYJJkgbJcjcUGQ7ddLRgT+tKYUw="
+    },
+    "fs-extra": {
+      "version": "0.26.7",
+      "resolved": "http://registry.npmjs.org/fs-extra/-/fs-extra-0.26.7.tgz",
+      "integrity": "sha1-muH92UiXeY7at20JGM9C0MMYT6k=",
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^2.1.0",
+        "klaw": "^1.0.0",
+        "path-is-absolute": "^1.0.0",
+        "rimraf": "^2.2.8"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "generate-function": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
+      "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
+      "requires": {
+        "is-property": "^1.0.2"
+      }
+    },
+    "generate-object-property": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+      "requires": {
+        "is-property": "^1.0.0"
+      }
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "requires": {
+        "assert-plus": "^1.0.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        }
+      }
+    },
+    "glob": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "graceful-fs": {
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
+    },
+    "handlebars": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.12.tgz",
+      "integrity": "sha512-RhmTekP+FZL+XNhwS1Wf+bTTZpdLougwt5pcgA1tuz6Jcx0fpH/7z0qd71RKnZHBCxIRBHfBOnio4gViPemNzA==",
+      "requires": {
+        "async": "^2.5.0",
+        "optimist": "^0.6.1",
+        "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4"
+      }
+    },
+    "har-validator": {
+      "version": "2.0.6",
+      "resolved": "http://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+      "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
+      "requires": {
+        "chalk": "^1.1.1",
+        "commander": "^2.9.0",
+        "is-my-json-valid": "^2.12.4",
+        "pinkie-promise": "^2.0.0"
+      }
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      }
+    },
+    "hasha": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/hasha/-/hasha-2.2.0.tgz",
+      "integrity": "sha1-eNfL/B5tZjA/55g3NlmEUXsvbuE=",
+      "requires": {
+        "is-stream": "^1.0.1",
+        "pinkie-promise": "^2.0.0"
+      }
+    },
+    "hawk": {
+      "version": "3.1.3",
+      "resolved": "http://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+      "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+      "requires": {
+        "boom": "2.x.x",
+        "cryptiles": "2.x.x",
+        "hoek": "2.x.x",
+        "sntp": "1.x.x"
+      }
+    },
+    "hoek": {
+      "version": "2.16.3",
+      "resolved": "http://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
+    },
+    "http-signature": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+      "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+      "requires": {
+        "assert-plus": "^0.2.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
+      }
+    },
+    "iconv-lite": {
+      "version": "0.4.6",
+      "resolved": "http://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.6.tgz",
+      "integrity": "sha1-45xoJhCnkfPu3Cc4L/SeJj+R+gk="
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "ini": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+    },
+    "ipaddr.js": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.0.5.tgz",
+      "integrity": "sha1-X6eM8wG4JceKvDBC2BJyMEnqI8c="
+    },
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+    },
+    "is-my-ip-valid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
+      "integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ=="
+    },
+    "is-my-json-valid": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.19.0.tgz",
+      "integrity": "sha512-mG0f/unGX1HZ5ep4uhRaPOS8EkAY8/j6mDRMJrutq4CqhoJWYp7qAlonIPy3TV7p3ju4TK9fo/PbnoksWmsp5Q==",
+      "requires": {
+        "generate-function": "^2.0.0",
+        "generate-object-property": "^1.1.0",
+        "is-my-ip-valid": "^1.0.0",
+        "jsonpointer": "^4.0.0",
+        "xtend": "^4.0.0"
+      }
+    },
+    "is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
+    },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+    },
+    "jsonfile": {
+      "version": "2.4.0",
+      "resolved": "http://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+      "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+      "requires": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "jsonpointer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk="
+    },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        }
+      }
+    },
+    "kew": {
+      "version": "0.7.0",
+      "resolved": "http://registry.npmjs.org/kew/-/kew-0.7.0.tgz",
+      "integrity": "sha1-edk9LTM2PW/dKXCzNdkUGtWR15s="
+    },
+    "kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "requires": {
+        "is-buffer": "^1.1.5"
+      }
+    },
+    "klaw": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
+      "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
+      "requires": {
+        "graceful-fs": "^4.1.9"
+      }
+    },
+    "lazy-cache": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4="
+    },
+    "lodash": {
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+    },
+    "longest": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
+    },
+    "media-typer": {
+      "version": "0.3.0",
+      "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+    },
+    "merge-descriptors": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-0.0.2.tgz",
+      "integrity": "sha1-w2pSp4FDdRPFcnXzndnTF1FKyMc="
+    },
+    "methods": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.1.tgz",
+      "integrity": "sha1-F+pjZgZtAMWON1uOx9/QRTyJgio="
+    },
+    "mime": {
+      "version": "1.2.11",
+      "resolved": "http://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
+      "integrity": "sha1-WCA+7Ybjpe8XrtK32evUfwpg3RA="
+    },
+    "mime-db": {
+      "version": "1.12.0",
+      "resolved": "http://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
+      "integrity": "sha1-PQxjGA9FjrENMlqqN9fFiuMS6dc="
+    },
+    "mime-types": {
+      "version": "2.0.14",
+      "resolved": "http://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
+      "integrity": "sha1-MQ4VnbI+B3+Lsit0jav6SVcUCqY=",
+      "requires": {
+        "mime-db": "~1.12.0"
+      }
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "0.0.10",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+      "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
+    },
+    "mkdirp": {
+      "version": "0.5.0",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+      "integrity": "sha1-HXMHam35hs2TROFecfzAWkyavxI=",
+      "requires": {
+        "minimist": "0.0.8"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+        }
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "native-or-bluebird": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/native-or-bluebird/-/native-or-bluebird-1.1.2.tgz",
+      "integrity": "sha1-OSHhECMtHreQ89rGG7NwUxx9NW4="
+    },
+    "nconf": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/nconf/-/nconf-0.7.2.tgz",
+      "integrity": "sha1-oF/fItwBw3jdXE3yfy3JC5qouwA=",
+      "requires": {
+        "async": "~0.9.0",
+        "ini": "1.x.x",
+        "yargs": "~3.15.0"
+      },
+      "dependencies": {
+        "async": {
+          "version": "0.9.2",
+          "resolved": "http://registry.npmjs.org/async/-/async-0.9.2.tgz",
+          "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0="
+        }
+      }
+    },
+    "negotiator": {
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz",
+      "integrity": "sha1-kuRrbbU8fkIe1koryU8IvnYw3z8="
+    },
+    "node-uuid": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
+      "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
+    },
+    "oauth-sign": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+    },
+    "on-finished": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.2.1.tgz",
+      "integrity": "sha1-XIXBzDYpn3gCllP2Z/J7a5nrwCk=",
+      "requires": {
+        "ee-first": "1.1.0"
+      }
+    },
+    "on-headers": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
+      "integrity": "sha1-ko9dD0cNSTQmUepnlLCFfBAGk/c="
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "optimist": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "requires": {
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
+      }
+    },
+    "parseurl": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
+      "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "path-to-regexp": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.3.tgz",
+      "integrity": "sha1-IbmrgidCed4lsVbqCP0SylG4rss="
+    },
+    "pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
+    },
+    "phantomjs": {
+      "version": "2.1.7",
+      "resolved": "http://registry.npmjs.org/phantomjs/-/phantomjs-2.1.7.tgz",
+      "integrity": "sha1-xpEPZ5NcNyhbYRQyn8LyfV8+MTQ=",
+      "requires": {
+        "extract-zip": "~1.5.0",
+        "fs-extra": "~0.26.4",
+        "hasha": "^2.2.0",
+        "kew": "~0.7.0",
+        "progress": "~1.1.8",
+        "request": "~2.67.0",
+        "request-progress": "~2.0.1",
+        "which": "~1.2.2"
+      }
+    },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "requires": {
+        "pinkie": "^2.0.0"
+      }
+    },
+    "process-nextick-args": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+    },
+    "progress": {
+      "version": "1.1.8",
+      "resolved": "http://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
+      "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74="
+    },
+    "proxy-addr": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.10.tgz",
+      "integrity": "sha1-DUCoL4Afw1VWfS7LZe/j8HfxIcU=",
+      "requires": {
+        "forwarded": "~0.1.0",
+        "ipaddr.js": "1.0.5"
+      }
+    },
+    "qs": {
+      "version": "2.3.3",
+      "resolved": "http://registry.npmjs.org/qs/-/qs-2.3.3.tgz",
+      "integrity": "sha1-6eha2+ddoLvkyOBHaghikPhjtAQ="
+    },
+    "range-parser": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.3.tgz",
+      "integrity": "sha1-aHKCNTXGkuLCoBA4Jq/YLC4P8XU="
+    },
+    "raw-body": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-1.3.2.tgz",
+      "integrity": "sha1-DhhvJ8X7/jJtizBid0gEVkoOz5M=",
+      "requires": {
+        "bytes": "1.0.0",
+        "iconv-lite": "0.4.6"
+      }
+    },
+    "readable-stream": {
+      "version": "2.0.6",
+      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+      "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~1.0.6",
+        "string_decoder": "~0.10.x",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+    },
+    "request": {
+      "version": "2.67.0",
+      "resolved": "http://registry.npmjs.org/request/-/request-2.67.0.tgz",
+      "integrity": "sha1-ivdHgOK/EeoK6aqWXBHxGv0nJ0I=",
+      "requires": {
+        "aws-sign2": "~0.6.0",
+        "bl": "~1.0.0",
+        "caseless": "~0.11.0",
+        "combined-stream": "~1.0.5",
+        "extend": "~3.0.0",
+        "forever-agent": "~0.6.1",
+        "form-data": "~1.0.0-rc3",
+        "har-validator": "~2.0.2",
+        "hawk": "~3.1.0",
+        "http-signature": "~1.1.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.7",
+        "node-uuid": "~1.4.7",
+        "oauth-sign": "~0.8.0",
+        "qs": "~5.2.0",
+        "stringstream": "~0.0.4",
+        "tough-cookie": "~2.2.0",
+        "tunnel-agent": "~0.4.1"
+      },
+      "dependencies": {
+        "mime-db": {
+          "version": "1.37.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
+          "integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg=="
+        },
+        "mime-types": {
+          "version": "2.1.21",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
+          "integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
+          "requires": {
+            "mime-db": "~1.37.0"
+          }
+        },
+        "qs": {
+          "version": "5.2.1",
+          "resolved": "http://registry.npmjs.org/qs/-/qs-5.2.1.tgz",
+          "integrity": "sha1-gB/uAw4LlFDWOFrcSKTMVbRK7fw="
+        }
+      }
+    },
+    "request-progress": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-2.0.1.tgz",
+      "integrity": "sha1-XTa7V5YcZzqlt4jbyBQf3yO0Tgg=",
+      "requires": {
+        "throttleit": "^1.0.0"
+      }
+    },
+    "right-align": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+      "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+      "requires": {
+        "align-text": "^0.1.1"
+      }
+    },
+    "rimraf": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "requires": {
+        "glob": "^7.0.5"
+      }
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "send": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.10.1.tgz",
+      "integrity": "sha1-d0XFDscvEVEVmA6PsXmuwBkA4Io=",
+      "requires": {
+        "debug": "~2.1.0",
+        "depd": "~1.0.0",
+        "destroy": "1.0.3",
+        "escape-html": "1.0.1",
+        "etag": "~1.5.0",
+        "fresh": "0.2.4",
+        "mime": "1.2.11",
+        "ms": "0.6.2",
+        "on-finished": "~2.1.1",
+        "range-parser": "~1.0.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.1.3",
+          "resolved": "http://registry.npmjs.org/debug/-/debug-2.1.3.tgz",
+          "integrity": "sha1-zoqxte6PvuK/o7Yzyrk9NmtjQY4=",
+          "requires": {
+            "ms": "0.7.0"
+          },
+          "dependencies": {
+            "ms": {
+              "version": "0.7.0",
+              "resolved": "http://registry.npmjs.org/ms/-/ms-0.7.0.tgz",
+              "integrity": "sha1-hlvpTC5zl62KV9pqYzpuLzB5i4M="
+            }
+          }
+        },
+        "ms": {
+          "version": "0.6.2",
+          "resolved": "http://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
+          "integrity": "sha1-2JwhJMb9wTU9Zai3e/GqxLGTcIw="
+        },
+        "on-finished": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.1.1.tgz",
+          "integrity": "sha1-+CyhyeOk8yhrG5k4YQ5bhja9PLI=",
+          "requires": {
+            "ee-first": "1.1.0"
+          }
+        }
+      }
+    },
+    "serve-static": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.7.2.tgz",
+      "integrity": "sha1-MWTOBtTmw0Wb3MnWAY+0+zXoSzk=",
+      "requires": {
+        "escape-html": "1.0.1",
+        "parseurl": "~1.3.0",
+        "send": "0.10.1",
+        "utils-merge": "1.0.0"
+      }
+    },
+    "sntp": {
+      "version": "1.0.9",
+      "resolved": "http://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+      "requires": {
+        "hoek": "2.x.x"
+      }
+    },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+    },
+    "sshpk": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.15.2.tgz",
+      "integrity": "sha512-Ra/OXQtuh0/enyl4ETZAfTaeksa6BXks5ZcjpSUNrjBr0DvrJKX+1fsKDPpT9TBXgHAFsa4510aNVgI8g/+SzA==",
+      "requires": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        }
+      }
+    },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+    },
+    "stringstream": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz",
+      "integrity": "sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA=="
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      }
+    },
+    "supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+    },
+    "throttleit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-1.0.0.tgz",
+      "integrity": "sha1-nnhYNtr0Z0MUWlmEtiaNgoUorGw="
+    },
+    "tough-cookie": {
+      "version": "2.2.2",
+      "resolved": "http://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz",
+      "integrity": "sha1-yDoYMPTl7wuT7yo0iOck+N4Basc="
+    },
+    "tunnel-agent": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+      "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us="
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+    },
+    "type-is": {
+      "version": "1.5.7",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.5.7.tgz",
+      "integrity": "sha1-uTaKWTzG730GReeLL0xky+zQXpA=",
+      "requires": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.0.9"
+      }
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+    },
+    "uglify-js": {
+      "version": "3.4.9",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
+      "integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
+      "optional": true,
+      "requires": {
+        "commander": "~2.17.1",
+        "source-map": "~0.6.1"
+      }
+    },
+    "uid-safe": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-1.1.0.tgz",
+      "integrity": "sha1-WNbF2r+N+9jVKDSDmAbAP9YUMjI=",
+      "requires": {
+        "base64-url": "1.2.1",
+        "native-or-bluebird": "~1.1.2"
+      }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "utils-merge": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
+      "integrity": "sha1-ApT7kiu5N1FTVBxPcJYjHyh8ivg="
+    },
+    "vary": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.0.1.tgz",
+      "integrity": "sha1-meSYFWaihhGN+yuBc1ffeZM3bRA="
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        }
+      }
+    },
+    "which": {
+      "version": "1.2.14",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
+      "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
+    "window-size": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
+      "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY="
+    },
+    "wordwrap": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "xtend": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+    },
+    "yargs": {
+      "version": "3.15.0",
+      "resolved": "http://registry.npmjs.org/yargs/-/yargs-3.15.0.tgz",
+      "integrity": "sha1-PZRG7yH7N5GzmFaQZi5LloPH8YE=",
+      "requires": {
+        "camelcase": "^1.0.2",
+        "cliui": "^2.1.0",
+        "decamelize": "^1.0.0",
+        "window-size": "^0.1.1"
+      }
+    },
+    "yauzl": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
+      "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
+      "requires": {
+        "fd-slicer": "~1.0.1"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aatt",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "Automated Accessibility Testing Tool",
   "main": "module.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "aatt",
   "version": "0.0.1",
   "description": "Automated Accessibility Testing Tool",
-  "main": "app.js",
+  "main": "module.js",
   "dependencies": {
     "body-parser": "~1.10.1",
     "consolidate": "~0.10.0",


### PR DESCRIPTION
Addresses https://github.com/paypal/AATT/issues/45

This lets you use the project as a node module, without the need for running it separately and using the web API.

Example usage:
```javascript
const { evaluate } = require('aatt');

evaluate({
    source: "<html xml:lang='en-gb'><head><title>foo</title></head><body><p>bar</p></body></html>",
    output: "json",
    engine: "htmlcs",
    level: "WCAG2A"
}).then(result => {
    console.log(JSON.parse(result));
});
```

I have bumped the version and set the `main` to the module.js. Running the project as a node/express website is unaffected by these changes, although the `evaluate` endpoint uses the module function now.